### PR TITLE
fix: Correctly set hooks and remap major modes to ts-modes for editing gears

### DIFF
--- a/lisp/gears/editing/go.el
+++ b/lisp/gears/editing/go.el
@@ -10,20 +10,21 @@
   :when (gearp! :editing go)
   :ensure (go-mode :ref "0ed3c5227e7f622589f1411b4939c3ee34711ebd")
   :hook
-  (go-mode-hook . electric-pair-local-mode)
-  (go-mode-hook .
-		(lambda ()
-		  (toggle-truncate-lines +1)
-		  (unless (gearp! :editing go -display-line-numbers)
-		    (display-line-numbers-mode +1))))
+  ((go-mode-hook go-ts-mode-hook) . electric-pair-local-mode)
+  ((go-mode-hook go-ts-mode-hook) .
+   (lambda ()
+     (toggle-truncate-lines +1)
+     (unless (gearp! :editing go -display-line-numbers)
+       (display-line-numbers-mode +1))))
   :config
   (leaf eglot
     :doc "Language Server Protocol support for go-mode"
     :when (gearp! :editing go lsp)
     :doctor ("gopls" . "the official language server protocol (lsp) implementation provided by the Go team")
-    :hook (go-mode-hook . eglot-ensure)
+    :hook ((go-mode-hook go-ts-mode-hook) . eglot-ensure)
     :config
-    (add-to-list 'eglot-server-programs '(go-mode . ("gopls" "serve"))))
+    (add-to-list 'eglot-server-programs '(go-mode . ("gopls" "serve")))
+    (add-to-list 'eglot-server-programs '(go-ts-mode . ("gopls" "serve"))))
 
   (leaf go-impl
     :doc "generates method stubs for implementing an interface"
@@ -34,7 +35,4 @@
   (leaf go-rename
     :doc "Integration of the 'gorename' tool into Emacs"
     :when (gearp! :editing go rename)
-    :doctor ("gorename" . "command that performs precise type-safe renaming of identifiers in Go source code"))
-
-  (unless (gearp! :editing go -treesit)
-    (setq go-ts-mode-hook go-mode-hook)))
+    :doctor ("gorename" . "command that performs precise type-safe renaming of identifiers in Go source code")))

--- a/lisp/gears/editing/go.el
+++ b/lisp/gears/editing/go.el
@@ -1,7 +1,9 @@
 ;; Declare tree-sitter languages needed by this gear
 (when (and (gearp! :editing go)
            (not (gearp! :editing go -treesit)))
-  (backpack-treesit-langs! go gomod))
+  (backpack-treesit-langs! go gomod)
+
+  (add-to-list 'major-mode-remap-alist '(go-mode . go-ts-mode)))
 
 (leaf go-mode
   :doc "Support for Go programming language in Emacs"
@@ -35,5 +37,4 @@
     :doctor ("gorename" . "command that performs precise type-safe renaming of identifiers in Go source code"))
 
   (unless (gearp! :editing go -treesit)
-    (add-to-list 'major-mode-remap-alist '(go-mode . go-ts-mode))
     (setq go-ts-mode-hook go-mode-hook)))

--- a/lisp/gears/editing/json.el
+++ b/lisp/gears/editing/json.el
@@ -1,7 +1,9 @@
 ;; Declare tree-sitter languages needed by this gear
 (when (and (gearp! :editing json)
            (not (gearp! :editing json -treesit)))
-  (backpack-treesit-langs! json))
+  (backpack-treesit-langs! json)
+
+  (add-to-list 'major-mode-remap-alist '(js-json-mode . json-ts-mode)))
 
 (leaf json
   :doc "major mode for editing JSON files"
@@ -24,5 +26,4 @@
   :doc "treesit support for editing JSON files"
   :when (and (gearp! :editing json) (not (gearp! :editing json -treesit)))
   :config
-  (add-to-list 'major-mode-remap-alist '(js-json-mode . json-ts-mode))
   (setq json-ts-mode-hook js-json-mode-hook))

--- a/lisp/gears/editing/json.el
+++ b/lisp/gears/editing/json.el
@@ -9,8 +9,8 @@
   :doc "major mode for editing JSON files"
   :when (gearp! :editing json)
   :hook
-  (js-json-mode-hook . electric-pair-local-mode)
-  (js-json-mode-hook .
+  ((js-json-mode-hook json-ts-mode-hook) . electric-pair-local-mode)
+  ((js-json-mode-hook json-ts-mode-hook) .
 		  (lambda ()
 		    (toggle-truncate-lines 1)
 		    (unless (gearp! :editing json -display-line-numbers)
@@ -20,10 +20,9 @@
     :when (gearp! :editing json lsp)
     :doc "Language Server Protocol support for JSON"
     :hook
-    (js-json-mode-hook . eglot-ensure)))
+    ((js-json-mode-hook json-ts-mode-hook) . eglot-ensure)))
 
 (leaf json-ts-mode
   :doc "treesit support for editing JSON files"
-  :when (and (gearp! :editing json) (not (gearp! :editing json -treesit)))
-  :config
-  (setq json-ts-mode-hook js-json-mode-hook))
+  :unless (gearp! :editing json -treesit)
+  :after json)

--- a/lisp/gears/editing/lua.el
+++ b/lisp/gears/editing/lua.el
@@ -1,7 +1,9 @@
 ;; Declare tree-sitter languages needed by this gear
 (when (and (gearp! :editing lua)
            (not (gearp! :editing lua -treesit)))
-  (backpack-treesit-langs! lua))
+  (backpack-treesit-langs! lua)
+
+  (add-to-list 'major-mode-remap-alist '(lua-mode . lua-ts-mode)))
 
 (leaf lua-mode
   :doc "A major-mode for editing Lua scripts"
@@ -25,5 +27,4 @@
     (add-to-list 'eglot-server-programs '(lua-mode . ("lua-language-server"))))
 
   (unless (gearp! :editing lua -treesit)
-    (add-to-list 'major-mode-remap-alist '(lua-mode . lua-ts-mode))
     (setq lua-ts-mode-hook lua-mode-hook)))

--- a/lisp/gears/editing/lua.el
+++ b/lisp/gears/editing/lua.el
@@ -10,21 +10,19 @@
   :ensure (lua-mode :ref "2f6b8d7a6317e42c953c5119b0119ddb337e0a5f")
   :when (gearp! :editing lua)
   :hook
-  (lua-mode-hook . electric-pair-local-mode)
-  (lua-mode-hook .
-		 (lambda ()
-		   (toggle-truncate-lines +1)
-		   (unless (gearp! :editing lua -display-line-numbers)
-		     (display-line-numbers-mode +1))))
+  ((lua-mode-hook lua-ts-mode-hook) . electric-pair-local-mode)
+  ((lua-mode-hook lua-ts-mode-hook) .
+   (lambda ()
+     (toggle-truncate-lines +1)
+     (unless (gearp! :editing lua -display-line-numbers)
+       (display-line-numbers-mode +1))))
   :config
   (leaf eglot
     :doc "Language Server Protocol support for lua-mode"
     :when (gearp! :editing lua lsp)
     :doctor
     ("lua-language-server" . "provides various language features for Lua to make development easier and faster")
-    :hook (lua-mode-hook . eglot-ensure)
+    :hook ((lua-mode-hook lua-ts-mode-hook) . eglot-ensure)
     :config
-    (add-to-list 'eglot-server-programs '(lua-mode . ("lua-language-server"))))
-
-  (unless (gearp! :editing lua -treesit)
-    (setq lua-ts-mode-hook lua-mode-hook)))
+    (add-to-list 'eglot-server-programs '(lua-mode . ("lua-language-server")))
+    (add-to-list 'eglot-server-programs '(lua-ts-mode . ("lua-language-server")))))

--- a/lisp/gears/editing/nix.el
+++ b/lisp/gears/editing/nix.el
@@ -10,33 +10,36 @@
   :ensure (nix-mode :ref "719feb7868fb567ecfe5578f6119892c771ac5e5")
   :when (gearp! :editing nix)
   :hook
-  (nix-mode-hook . electric-pair-local-mode)
-  (nix-mode-hook . (lambda ()
-		     (toggle-truncate-lines +1)
-		     (unless (gearp! :editing nix -display-line-numbers)
-		       (display-line-numbers-mode +1)))))
+  ((nix-mode-hook nix-ts-mode-hook) . electric-pair-local-mode)
+  ((nix-mode-hook nix-ts-mode-hook) .
+   (lambda ()
+     (toggle-truncate-lines +1)
+     (unless (gearp! :editing nix -display-line-numbers)
+       (display-line-numbers-mode +1)))))
 
 (leaf eglot
-    :doc "Language Server Protocol support for nix-mode"
-    :when (and (gearp! :editing nix lsp) (gearp! :editing nix))
-    :doctor
-    ("nixd" . "a feature-rich nix language server interoperating with C++ nix")
-    ("nil"  . "an incremental analysis assistant for writing in Nix")
-    ("nixfmt" . "format Nix source code, used with your LSP server of choice")
-    ("alejandra" . "the Uncompromising Nix Code Formatter, used with your LSP server of choice")
-    :hook
-    (nix-mode-hook . eglot-ensure)
-    :config
-    (add-to-list 'eglot-server-programs
-		 `(nix-mode . ,(eglot-alternatives '(("nixd")
+  :doc "Language Server Protocol support for nix-mode"
+  :when (and (gearp! :editing nix lsp) (gearp! :editing nix))
+  :doctor
+  ("nixd" . "a feature-rich nix language server interoperating with C++ nix")
+  ("nil"  . "an incremental analysis assistant for writing in Nix")
+  ("nixfmt" . "format Nix source code, used with your LSP server of choice")
+  ("alejandra" . "the Uncompromising Nix Code Formatter, used with your LSP server of choice")
+  :hook
+  ((nix-mode-hook nix-ts-mode-hook) . eglot-ensure)
+  :config
+  (add-to-list 'eglot-server-programs
+	       `(nix-mode . ,(eglot-alternatives '(("nixd")
+						   ("nil" "--stdio")))))
+  (add-to-list 'eglot-server-programs
+		 `(nix-ts-mode . ,(eglot-alternatives '(("nixd")
 						     ("nil" "--stdio"))))))
 
 (leaf nix-ts-mode
   :doc "tree-sitter major mode for nix"
   :ensure (nix-ts-mode :ref "d769e53ccc0f40026fd11c7e23bf419c2caf4732")
   :unless (gearp! :editing nix -treesit)
-  :config
-  (setq nix-ts-mode-hook nix-mode-hook))
+  :after nix-mode)
 
 (leaf ob-nix
   :doc "a simple org-babel language extension to evaluate nix expressions using `nix-instantiate`"

--- a/lisp/gears/editing/nix.el
+++ b/lisp/gears/editing/nix.el
@@ -1,7 +1,9 @@
 ;; Declare tree-sitter languages needed by this gear
 (when (and (gearp! :editing nix)
            (not (gearp! :editing nix -treesit)))
-  (backpack-treesit-langs! nix))
+  (backpack-treesit-langs! nix)
+
+  (add-to-list 'major-mode-remap-alist '(nix-mode . nix-ts-mode)))
 
 (leaf nix-mode
   :doc "an Emacs major mode for editing Nix expressions"
@@ -34,7 +36,6 @@
   :ensure (nix-ts-mode :ref "d769e53ccc0f40026fd11c7e23bf419c2caf4732")
   :unless (gearp! :editing nix -treesit)
   :config
-  (add-to-list 'major-mode-remap-alist '(nix-mode . nix-ts-mode))
   (setq nix-ts-mode-hook nix-mode-hook))
 
 (leaf ob-nix

--- a/lisp/gears/editing/python.el
+++ b/lisp/gears/editing/python.el
@@ -10,8 +10,8 @@
   :ensure (python-mode :ref "5aaf8b386aa694429d997c6fd49772b0b359e514")
   :when (gearp! :editing python)
   :hook
-  ((python-mode-hook python-ts-mode-map) . electric-pair-local-mode)
-  ((python-mode-hook python-ts-mode-map) .
+  ((python-mode-hook python-ts-mode-hook) . electric-pair-local-mode)
+  ((python-mode-hook python-ts-mode-hook) .
    (lambda ()
      (toggle-truncate-lines 1)
      (unless (gearp! :editing python -display-line-numbers)
@@ -21,7 +21,7 @@
     :doc "Language Server Protocol support for python"
     :when (gearp! :editing python lsp)
     :hook
-    ((python-mode-hook python-ts-mode-map) . eglot-ensure)
+    ((python-mode-hook python-ts-mode-hook) . eglot-ensure)
     :config
     (add-to-list 'eglot-server-programs
 		 `(python-mode . ,(eglot-alternatives

--- a/lisp/gears/editing/python.el
+++ b/lisp/gears/editing/python.el
@@ -1,7 +1,9 @@
 ;; Declare tree-sitter languages needed by this gear
 (when (and (gearp! :editing python)
            (not (gearp! :editing python -treesit)))
-  (backpack-treesit-langs! python))
+  (backpack-treesit-langs! python)
+
+  (add-to-list 'major-mode-remap-alist '(python-mode . python-ts-mode)))
 
 (leaf python-mode
   :doc "major mode for the Python Programming Language"
@@ -54,5 +56,4 @@
   :after python
   :unless (gearp! :editing python -treesit)
   :config
-  (add-to-list 'major-mode-remap-alist '(python-mode . python-ts-mode))
   (setq python-ts-mode-hook python-mode-hook))

--- a/lisp/gears/editing/python.el
+++ b/lisp/gears/editing/python.el
@@ -10,18 +10,18 @@
   :ensure (python-mode :ref "5aaf8b386aa694429d997c6fd49772b0b359e514")
   :when (gearp! :editing python)
   :hook
-  (python-mode-hook . electric-pair-local-mode)
-  (python-mode-hook .
-		    (lambda ()
-		      (toggle-truncate-lines 1)
-		      (unless (gearp! :editing python -display-line-numbers)
-			(display-line-numbers-mode +1))))
+  ((python-mode-hook python-ts-mode-map) . electric-pair-local-mode)
+  ((python-mode-hook python-ts-mode-map) .
+   (lambda ()
+     (toggle-truncate-lines 1)
+     (unless (gearp! :editing python -display-line-numbers)
+       (display-line-numbers-mode +1))))
   :config
   (leaf eglot
     :doc "Language Server Protocol support for python"
     :when (gearp! :editing python lsp)
     :hook
-    (python-mode-hook . eglot-ensure)
+    ((python-mode-hook python-ts-mode-map) . eglot-ensure)
     :config
     (add-to-list 'eglot-server-programs
 		 `(python-mode . ,(eglot-alternatives
@@ -32,6 +32,16 @@
 				     ("pyrefly" "lsp")
 				     "jedi-language-server"
 				     ("ruff" "server")))))
+
+    (add-to-list 'eglot-server-programs
+		 `(python-ts-mode . ,(eglot-alternatives
+				      '("pylsp"
+					"pyls"
+					("basedpyright-langserver" "--stdio")
+					("pyright-langserver" "--stdio")
+					("pyrefly" "lsp")
+					"jedi-language-server"
+					("ruff" "server")))))
     :doctor
     ("pylsp" . "python implementation of the Language Server Protocol")
     ("pyls"  . "an implementation of the Language Server Protocol for Python")
@@ -43,7 +53,7 @@
 
 (leaf ob-python
   :doc "Python source blocks in org-mode"
-  :when (and (gearp! :editing python) (gearp! :editing org))
+  :when (gearp! :editing python)
   :after org
   :custom
   (org-babel-python-command . "python3")
@@ -55,5 +65,4 @@
   :doc "tree-sitter support for Python"
   :after python
   :unless (gearp! :editing python -treesit)
-  :config
-  (setq python-ts-mode-hook python-mode-hook))
+  :after python)


### PR DESCRIPTION
The code I implemented to remap major modes and set the `*-ts-mode-hook` on each editing gear was severely incorrect. `major-mode-remap-alist` should be set as early as possible, and each tree-sitter major mode should have its hook set regardless of the user choosing to use tree-sitter or not, as setting such variables does not cause Emacs start to fail.