### PR TITLE
new: Add support for Terraform

### DIFF
--- a/lisp/backpack.el
+++ b/lisp/backpack.el
@@ -968,6 +968,7 @@ The behavior depends on `backpack-mode':
   (load (expand-file-name "gears/editing/python" backpack-core-dir))
   (load (expand-file-name "gears/editing/rst" backpack-core-dir))
   (load (expand-file-name "gears/editing/rust" backpack-core-dir))
+  (load (expand-file-name "gears/editing/terraform" backpack-core-dir))
   (load (expand-file-name "gears/editing/toml" backpack-core-dir)))
 
 ;;; Garbage Collection (orphaned packages cleanup)

--- a/lisp/gears/editing/terraform.el
+++ b/lisp/gears/editing/terraform.el
@@ -7,6 +7,7 @@
     (add-to-list 'treesit-auto-recipe-list
 		 (make-treesit-auto-recipe
 		  :lang 'terraform
+		  :ts-mode 'terraform-ts-mode
 		  :url "https://github.com/tree-sitter-grammars/tree-sitter-hcl"
 		  :source-dir "dialects/terraform/src")))
 
@@ -38,8 +39,3 @@
   :doc "Look up Terraform documentation from Emacs"
   :when (gearp! :editing terraform doc)
   :ensure (terraform-doc :ref "31f1c47453ad14181883f78258a72c02b95d9783"))
-
-(leaf terraform-ts-mode
-  :doc "treesit support for editing Terraform files"
-  :unless (gearp! :editing terraform -treesit)
-  :after terraform-mode)

--- a/lisp/gears/editing/terraform.el
+++ b/lisp/gears/editing/terraform.el
@@ -1,7 +1,14 @@
 ;; Declare tree-sitter languages needed by this gear
 (when (and (gearp! :editing terraform)
            (not (gearp! :editing terraform -treesit)))
-  (backpack-treesit-langs! hcl)
+  (backpack-treesit-langs! terraform)
+
+  (with-eval-after-load 'treesit-auto
+    (add-to-list 'treesit-auto-recipe-list
+		 (make-treesit-auto-recipe
+		  :lang 'terraform
+		  :url "https://github.com/tree-sitter-grammars/tree-sitter-hcl"
+		  :source-dir "dialects/terraform/src")))
 
   (add-to-list 'major-mode-remap-alist '(terraform-mode . terraform-ts-mode)))
 

--- a/lisp/gears/editing/terraform.el
+++ b/lisp/gears/editing/terraform.el
@@ -1,6 +1,8 @@
 ;; Declare tree-sitter languages needed by this gear
 (when (and (gearp! :editing terraform)
-           (not (gearp! :editing terraform -treesit)))
+	   (not (gearp! :editing terraform -treesit))
+	   ;; NOTE(shackra): disabled until I can figure out the reason for this error: Ignoring unknown mode ‘terraform-mode’ (remapped to `terraform-ts-mode')
+	   nil)
   (backpack-treesit-langs! terraform)
 
   (with-eval-after-load 'treesit-auto

--- a/lisp/gears/editing/terraform.el
+++ b/lisp/gears/editing/terraform.el
@@ -31,3 +31,8 @@
     :doc "Look up Terraform documentation from Emacs"
     :when (gearp! :editing terraform doc)
     :ensure (terraform-doc :ref "31f1c47453ad14181883f78258a72c02b95d9783")))
+
+(leaf terraform-ts-mode
+  :doc "treesit support for editing Terraform files"
+  :unless (gearp! :editing terraform -treesit)
+  :after terraform-mode)

--- a/lisp/gears/editing/terraform.el
+++ b/lisp/gears/editing/terraform.el
@@ -32,12 +32,12 @@
     :hook ((terraform-mode-hook terraform-ts-mode-hook) . eglot-ensure)
     :config
     (add-to-list 'eglot-server-programs '(terraform-mode . ("terraform-ls" "serve")))
-    (add-to-list 'eglot-server-programs '(terraform-ts-mode . ("terraform-ls" "serve"))))
+    (add-to-list 'eglot-server-programs '(terraform-ts-mode . ("terraform-ls" "serve")))))
 
-  (leaf terraform-doc
-    :doc "Look up Terraform documentation from Emacs"
-    :when (gearp! :editing terraform doc)
-    :ensure (terraform-doc :ref "31f1c47453ad14181883f78258a72c02b95d9783")))
+(leaf terraform-doc
+  :doc "Look up Terraform documentation from Emacs"
+  :when (gearp! :editing terraform doc)
+  :ensure (terraform-doc :ref "31f1c47453ad14181883f78258a72c02b95d9783"))
 
 (leaf terraform-ts-mode
   :doc "treesit support for editing Terraform files"

--- a/lisp/gears/editing/terraform.el
+++ b/lisp/gears/editing/terraform.el
@@ -1,0 +1,33 @@
+;; Declare tree-sitter languages needed by this gear
+(when (and (gearp! :editing terraform)
+           (not (gearp! :editing terraform -treesit)))
+  (backpack-treesit-langs! hcl)
+
+  (add-to-list 'major-mode-remap-alist '(terraform-mode . terraform-ts-mode)))
+
+(leaf terraform-mode
+  :doc "A major-mode for editing Terraform configuration files"
+  :ensure (terraform-mode :ref "01635df3625c0cec2bb4613a6f920b8569d41009")
+  :when (gearp! :editing terraform)
+  :hook
+  ((terraform-mode-hook terraform-ts-mode-hook) . electric-pair-local-mode)
+  ((terraform-mode-hook terraform-ts-mode-hook) .
+   (lambda ()
+     (toggle-truncate-lines +1)
+     (unless (gearp! :editing terraform -display-line-numbers)
+       (display-line-numbers-mode +1))))
+  :config
+  (leaf eglot
+    :doc "Language Server Protocol support for terraform-mode"
+    :when (gearp! :editing terraform lsp)
+    :doctor
+    ("terraform-ls" . "the official Terraform Language Server by HashiCorp")
+    :hook ((terraform-mode-hook terraform-ts-mode-hook) . eglot-ensure)
+    :config
+    (add-to-list 'eglot-server-programs '(terraform-mode . ("terraform-ls" "serve")))
+    (add-to-list 'eglot-server-programs '(terraform-ts-mode . ("terraform-ls" "serve"))))
+
+  (leaf terraform-doc
+    :doc "Look up Terraform documentation from Emacs"
+    :when (gearp! :editing terraform doc)
+    :ensure (terraform-doc :ref "31f1c47453ad14181883f78258a72c02b95d9783")))


### PR DESCRIPTION
Support for tree-sitter is not available, as I'm seeing this error when visiting a .tf file:

```
Ignoring unknown mode  terraform-mode  (remapped to `terraform-ts-mode')
```