### PR TITLE
chore: Improve org-mode support and appearance

### DIFF
--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -47,7 +47,7 @@
 
   ;; Make the document title a bit bigger
   (set-face-attribute 'org-document-title nil   :weight 'bold :height 1.8)
-  (set-face-attribute 'org-block nil            :foreground nil :inherit 'fixed-pitch :height 0.85)
+  (set-face-attribute 'org-block nil            :foreground 'unspecified :inherit 'fixed-pitch :height 0.85)
   (set-face-attribute 'org-code nil             :inherit '(shadow fixed-pitch) :height 0.85)
   (set-face-attribute 'org-indent nil           :inherit '(org-hide fixed-pitch) :height 0.85)
   (set-face-attribute 'org-verbatim nil         :inherit '(shadow fixed-pitch) :height 0.85)

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -3,9 +3,11 @@
   :when (gearp! :editing org)
   :mode "\\.org\\'"
   :ensure (org :ref "8b15a0d0b48a0e3ce09be0d208d74a01743cbbe0" :host github :repo "emacs-straight/org-mode")
-  :hook (org-mode-hook . (lambda ()
-			   (when (gearp! :editing org display-line-numbers)
-			     (display-line-numbers-mode)))))
+  :hook
+  (org-mode-hook . (lambda ()
+		     (when (gearp! :editing org display-line-numbers)
+		       (display-line-numbers-mode))))
+  (org-mode-hook . visual-line-mode))
 
 (leaf org-modern
   :doc "a modern style for your Org buffers using font locking and text properties"

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -48,18 +48,19 @@
 	 (not (string-empty-p (string-trim org-roam-directory)))
 	 (file-directory-p (expand-file-name org-roam-directory))))
   :advice
-  (:before org-roam-db-autosync-mode
-	   (lambda (orig-func &rest arg)
-	     (when arg
-	       (if (not (backpack--org-roam-check-directory))
-		   (user-error "`org-roam-directory' not set or does not exist")
-		 (apply orig-func arg)))))
+  (:around org-roam-db-autosync-mode
+   (lambda (orig-fun arg &rest args)
+     (if (and (or (null arg)
+                  (eq arg t)
+                  (and (numberp arg) (> arg 0)))
+              (not (backpack--org-roam-check-directory)))
+         (user-error "`org-roam-directory' not set or does not exist")
+       (apply orig-fun arg args))))
 
   (:before org-roam-db-sync
-	   (lambda (orig-func &rest arg)
+	   (lambda (&rest _)
 	     (if (not (backpack--org-roam-check-directory))
-		 (user-error "`org-roam-directory' not set or does not exist")
-	       (appy orig-func arg))))
+		 (user-error "`org-roam-directory' not set or does not exist"))))
 
   :global-minor-mode org-roam-db-autosync-mode)
 

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -19,6 +19,14 @@
   :ensure (mixed-pitch :ref "519e05f74825abf04b7d2e0e38ec040d013a125a" :host gitlab :repo "jabranham/mixed-pitch")
   :hook (org-mode-hook . mixed-pitch-mode))
 
+(leaf olivetti
+  :doc "a simple Emacs minor mode for a nice writing environment"
+  :url "https://github.com/rnkn/olivetti"
+  :unless (gearp! :editing org -centered)
+  :after org
+  :ensure (olivetti :ref "845eb7a95a3ca3325f1120c654d761b91683f598" :host github :repo "rnkn/olivetti")
+  :hook (org-mode-hook . olivetti-mode))
+
 (leaf org-modern
   :doc "a modern style for your Org buffers using font locking and text properties"
   :unless (gearp! :editing -modern)

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -23,9 +23,37 @@
   (org-pretty-entities			.	t)
   (org-agenda-tags-column		.	0)
   (org-ellipsis				.	"…")
+  (org-src-fontify-natively		.	t)
+  (org-src-tab-acts-natively		.	t)
+  (org-edit-src-content-indentation	.	0)
   :global-minor-mode global-org-modern-mode
   :hook
-  (org-mode-hook . (lambda () (setq line-spacing 0.2))))
+  (org-mode-hook . (lambda () (setq line-spacing 0.2)))
+  (org-mode-hook . variable-pitch-mode)
+  :config
+  ;; Resize Org headings
+  (dolist (face '((org-level-1 . 1.35)
+                  (org-level-2 . 1.3)
+                  (org-level-3 . 1.2)
+                  (org-level-4 . 1.1)
+                  (org-level-5 . 1.1)
+                  (org-level-6 . 1.1)
+                  (org-level-7 . 1.1)
+                  (org-level-8 . 1.1)))
+    (set-face-attribute (car face) nil :weight 'bold :height (cdr face)))
+
+  (require 'org-indent)
+  (set-face-attribute 'org-indent nil :inherit '(org-hide fixed-pitch))
+
+  ;; Make the document title a bit bigger
+  (set-face-attribute 'org-document-title nil   :weight 'bold :height 1.8)
+  (set-face-attribute 'org-block nil            :foreground nil :inherit 'fixed-pitch :height 0.85)
+  (set-face-attribute 'org-code nil             :inherit '(shadow fixed-pitch) :height 0.85)
+  (set-face-attribute 'org-indent nil           :inherit '(org-hide fixed-pitch) :height 0.85)
+  (set-face-attribute 'org-verbatim nil         :inherit '(shadow fixed-pitch) :height 0.85)
+  (set-face-attribute 'org-special-keyword nil  :inherit '(font-lock-comment-face fixed-pitch))
+  (set-face-attribute 'org-meta-line nil        :inherit '(font-lock-comment-face fixed-pitch))
+  (set-face-attribute 'org-checkbox nil         :inherit 'fixed-pitch))
 
 (leaf org-roam
   :doc "a plain-text knowledge management system. It brings some of Roam's more powerful features into the Org-mode ecosystem"
@@ -51,13 +79,13 @@
 	 (file-directory-p (expand-file-name org-roam-directory))))
   :advice
   (:around org-roam-db-autosync-mode
-   (lambda (orig-fun arg &rest args)
-     (if (and (or (null arg)
-                  (eq arg t)
-                  (and (numberp arg) (> arg 0)))
-              (not (backpack--org-roam-check-directory)))
-         (user-error "`org-roam-directory' not set or does not exist, please set it in your private configuration")
-       (apply orig-fun arg args))))
+	   (lambda (orig-fun arg &rest args)
+	     (if (and (or (null arg)
+			  (eq arg t)
+			  (and (numberp arg) (> arg 0)))
+		      (not (backpack--org-roam-check-directory)))
+		 (user-error "`org-roam-directory' not set or does not exist, please set it in your private configuration")
+	       (apply orig-fun arg args))))
 
   (:before org-roam-db-sync
 	   (lambda (&rest _)

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -60,7 +60,6 @@
   (set-face-attribute 'org-document-title nil   :weight 'bold :height 1.6)
   (set-face-attribute 'org-block nil            :foreground 'unspecified :inherit 'fixed-pitch :height 0.85)
   (set-face-attribute 'org-code nil             :inherit '(shadow fixed-pitch) :height 0.85)
-  (set-face-attribute 'org-indent nil           :inherit '(org-hide fixed-pitch) :height 0.85)
   (set-face-attribute 'org-verbatim nil         :inherit '(shadow fixed-pitch) :height 0.85)
   (set-face-attribute 'org-special-keyword nil  :inherit '(font-lock-comment-face fixed-pitch))
   (set-face-attribute 'org-meta-line nil        :inherit '(font-lock-comment-face fixed-pitch))

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -31,8 +31,6 @@
   :when (gearp! :editing org roam)
   :after org
   :ensure (org-roam :ref "7cd906b6f8b18a21766228f074aff24586770934" :host github :repo "org-roam/org-roam")
-  :custom
-  (org-roam-directory . "") ;; NOTE: user needs to set this value
   :setq
   (org-roam-node-display-template .  `,(concat "${title:*} " (propertize "${tags:10}" 'face 'org-tag)))
   :bind

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -3,9 +3,9 @@
   :when (gearp! :editing org)
   :mode "\\.org\\'"
   :ensure (org :ref "8b15a0d0b48a0e3ce09be0d208d74a01743cbbe0" :host github :repo "emacs-straight/org-mode")
-  :config
-  (when (gearp! :editing org display-line-numbers)
-    (add-hook 'org-mode-hook #'display-line-numbers-mode)))
+  :hook (org-mode-hook . (lambda ()
+			   (when (gearp! :editing org display-line-numbers)
+			     (display-line-numbers-mode)))))
 
 (leaf org-modern
   :doc "a modern style for your Org buffers using font locking and text properties"

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -41,6 +41,26 @@
   ("C-c n c" . org-roam-capture)
   ;; for daily notes
   ("C-c n j" . org-roam-dailies-capture-today)
+  :preface
+  (defun backpack--org-roam-check-directory ()
+    "Return t if `org-roam-directory' has a valid directory"
+    (and (stringp org-roam-directory)
+	 (not (string-empty-p (string-trim org-roam-directory)))
+	 (file-directory-p (expand-file-name org-roam-directory))))
+  :advice
+  (:before org-roam-db-autosync-mode
+	   (lambda (orig-func &rest arg)
+	     (when arg
+	       (if (not (backpack--org-roam-check-directory))
+		   (user-error "`org-roam-directory' not set or does not exist")
+		 (apply orig-func arg)))))
+
+  (:before org-roam-db-sync
+	   (lambda (orig-func &rest arg)
+	     (if (not (backpack--org-roam-check-directory))
+		 (user-error "`org-roam-directory' not set or does not exist")
+	       (appy orig-func arg))))
+
   :global-minor-mode org-roam-db-autosync-mode)
 
 (leaf org-noter

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -54,13 +54,13 @@
                   (eq arg t)
                   (and (numberp arg) (> arg 0)))
               (not (backpack--org-roam-check-directory)))
-         (user-error "`org-roam-directory' not set or does not exist")
+         (user-error "`org-roam-directory' not set or does not exist, please set it in your private configuration")
        (apply orig-fun arg args))))
 
   (:before org-roam-db-sync
 	   (lambda (&rest _)
 	     (if (not (backpack--org-roam-check-directory))
-		 (user-error "`org-roam-directory' not set or does not exist"))))
+		 (user-error "`org-roam-directory' not set or does not exist, please set it in your private configuration"))))
 
   :global-minor-mode org-roam-db-autosync-mode)
 

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -9,7 +9,8 @@
 		       (display-line-numbers-mode))))
   (org-mode-hook . visual-line-mode)
   :custom
-  (org-startup-with-latex-preview . t))
+  (org-startup-with-latex-preview . t)
+  (org-src-window-setup . 'other-window))
 
 (leaf mixed-pitch
   :doc "a minor mode that enables mixing fixed-pitch (also known as fixed-width or monospace) and variable-pitch (AKA “proportional”) fonts"
@@ -31,7 +32,7 @@
 
 (leaf org-modern
   :doc "a modern style for your Org buffers using font locking and text properties"
-  :unless (gearp! :editing -modern)
+  :unless (gearp! :editing org -modern)
   :ensure (org-modern :ref "713beb72aed4db43f8a10feed72136e931eb674a" :host github :repo "minad/org-modern")
   :custom
   (org-adapt-indentation		.	t)
@@ -50,7 +51,6 @@
   :global-minor-mode global-org-modern-mode
   :hook
   (org-mode-hook . (lambda () (setq line-spacing 0.2)))
-  (org-mode-hook . variable-pitch-mode)
   :config
   ;; Resize Org headings
   (dolist (face '((org-level-1 . 1.25)
@@ -81,6 +81,7 @@
   :when (gearp! :editing org roam)
   :after org
   :ensure (org-roam :ref "7cd906b6f8b18a21766228f074aff24586770934" :host github :repo "org-roam/org-roam")
+  :doctor ("sqlite3" . ("SQLite database engine" required))
   :setq
   (org-roam-node-display-template .  `,(concat "${title:*} " (propertize "${tags:10}" 'face 'org-tag)))
   :bind
@@ -120,3 +121,18 @@
   :when (gearp! :editing org noter)
   :after org
   :ensure (org-noter :ref "9ead81d42dd4dd5074782d239b2efddf9b8b7b3d" :host github :repo "weirdNox/org-noter"))
+
+(leaf org-appear
+  :doc "toggle hidden Org mode element parts on cursor hover"
+  :when (gearp! :editing org appear)
+  :after org
+  :ensure (org-appear :ref "32ee50f8fdfa449bbc235617549c1bccb503cb09" :host github :repo "awth13/org-appear")
+  :hook (org-mode-hook . org-appear-mode))
+
+(leaf ob-org
+  :doc "Org source blocks in org-mode"
+  :when (gearp! :editing org)
+  :after org
+  :config
+  (org-babel-do-load-languages
+   'org-babel-load-languages (append org-babel-load-languages '((org . t)))))

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -7,7 +7,9 @@
   (org-mode-hook . (lambda ()
 		     (when (gearp! :editing org display-line-numbers)
 		       (display-line-numbers-mode))))
-  (org-mode-hook . visual-line-mode))
+  (org-mode-hook . visual-line-mode)
+  :custom
+  (org-startup-with-latex-preview . t))
 
 (leaf mixed-pitch
   :doc "a minor mode that enables mixing fixed-pitch (also known as fixed-width or monospace) and variable-pitch (AKA “proportional”) fonts"
@@ -22,42 +24,40 @@
   :unless (gearp! :editing -modern)
   :ensure (org-modern :ref "713beb72aed4db43f8a10feed72136e931eb674a" :host github :repo "minad/org-modern")
   :custom
-  (org-auto-align-tags			.	nil)
-  (org-tags-column			.	0)
-  (org-catch-invisible-edits		.	'show-and-error)
-  (org-special-ctrl-a/e			.	t)
-  (org-insert-heading-respect-content	.	t)
-  (org-hide-emphasis-markers		.	t)
-  (org-pretty-entities			.	t)
+  (org-adapt-indentation		.	t)
   (org-agenda-tags-column		.	0)
+  (org-auto-align-tags			.	nil)
+  (org-catch-invisible-edits		.	'show-and-error)
+  (org-edit-src-content-indentation	.	0)
   (org-ellipsis				.	"…")
+  (org-hide-emphasis-markers		.	t)
+  (org-insert-heading-respect-content	.	t)
+  (org-pretty-entities			.	t)
+  (org-special-ctrl-a/e			.	t)
   (org-src-fontify-natively		.	t)
   (org-src-tab-acts-natively		.	t)
-  (org-edit-src-content-indentation	.	0)
+  (org-tags-column			.	0)
   :global-minor-mode global-org-modern-mode
   :hook
   (org-mode-hook . (lambda () (setq line-spacing 0.2)))
   (org-mode-hook . variable-pitch-mode)
   :config
   ;; Resize Org headings
-  (dolist (face '((org-level-1 . 1.35)
-                  (org-level-2 . 1.3)
+  (dolist (face '((org-level-1 . 1.25)
+                  (org-level-2 . 1.2)
                   (org-level-3 . 1.2)
-                  (org-level-4 . 1.1)
-                  (org-level-5 . 1.1)
-                  (org-level-6 . 1.1)
-                  (org-level-7 . 1.1)
-                  (org-level-8 . 1.1)))
+                  (org-level-4 . 1.2)
+                  (org-level-5 . 1.2)
+                  (org-level-6 . 1.2)
+                  (org-level-7 . 1.2)
+                  (org-level-8 . 1.2)))
     (set-face-attribute (car face) nil :weight 'bold :height (cdr face)))
-
-  (require 'org-indent)
-  (set-face-attribute 'org-indent nil :inherit '(org-hide fixed-pitch))
 
   ;; increase the size of LaTeX-previews
   (plist-put org-format-latex-options :scale 2)
 
   ;; Make the document title a bit bigger
-  (set-face-attribute 'org-document-title nil   :weight 'bold :height 1.8)
+  (set-face-attribute 'org-document-title nil   :weight 'bold :height 1.6)
   (set-face-attribute 'org-block nil            :foreground 'unspecified :inherit 'fixed-pitch :height 0.85)
   (set-face-attribute 'org-code nil             :inherit '(shadow fixed-pitch) :height 0.85)
   (set-face-attribute 'org-indent nil           :inherit '(org-hide fixed-pitch) :height 0.85)

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -45,6 +45,9 @@
   (require 'org-indent)
   (set-face-attribute 'org-indent nil :inherit '(org-hide fixed-pitch))
 
+  ;; increase the size of LaTeX-previews
+  (plist-put org-format-latex-options :scale 2)
+
   ;; Make the document title a bit bigger
   (set-face-attribute 'org-document-title nil   :weight 'bold :height 1.8)
   (set-face-attribute 'org-block nil            :foreground 'unspecified :inherit 'fixed-pitch :height 0.85)

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -64,7 +64,7 @@
 	     (if (not (backpack--org-roam-check-directory))
 		 (user-error "`org-roam-directory' not set or does not exist, please set it in your private configuration"))))
 
-  :global-minor-mode org-roam-db-autosync-mode)
+  :hook (after-init-hook .  org-roam-db-autosync-mode))
 
 (leaf org-noter
   :doc "a synchronized, Org-mode, document annotator"

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -21,7 +21,9 @@
   (org-pretty-entities			.	t)
   (org-agenda-tags-column		.	0)
   (org-ellipsis				.	"…")
-  :global-minor-mode global-org-modern-mode)
+  :global-minor-mode global-org-modern-mode
+  :hook
+  (org-mode-hook . (lambda () (setq line-spacing 0.2))))
 
 (leaf org-roam
   :doc "a plain-text knowledge management system. It brings some of Roam's more powerful features into the Org-mode ecosystem"

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -25,7 +25,9 @@
   :unless (gearp! :editing org -centered)
   :after org
   :ensure (olivetti :ref "845eb7a95a3ca3325f1120c654d761b91683f598" :host github :repo "rnkn/olivetti")
-  :hook (org-mode-hook . olivetti-mode))
+  :hook (org-mode-hook . olivetti-mode)
+  :custom
+  (olivetti-body-width . 0.618033988749)) ;; large segment in gold proportion
 
 (leaf org-modern
   :doc "a modern style for your Org buffers using font locking and text properties"

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -9,6 +9,14 @@
 		       (display-line-numbers-mode))))
   (org-mode-hook . visual-line-mode))
 
+(leaf mixed-pitch
+  :doc "a minor mode that enables mixing fixed-pitch (also known as fixed-width or monospace) and variable-pitch (AKA “proportional”) fonts"
+  :url "https://gitlab.com/jabranham/mixed-pitch"
+  :unless (gearp! :editing org -mixed-pitch)
+  :after org
+  :ensure (mixed-pitch :ref "519e05f74825abf04b7d2e0e38ec040d013a125a" :host gitlab :repo "jabranham/mixed-pitch")
+  :hook (org-mode-hook . mixed-pitch-mode))
+
 (leaf org-modern
   :doc "a modern style for your Org buffers using font locking and text properties"
   :unless (gearp! :editing -modern)

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -32,7 +32,7 @@
   :after org
   :ensure (org-roam :ref "7cd906b6f8b18a21766228f074aff24586770934" :host github :repo "org-roam/org-roam")
   :custom
-  (org-roam-directory . nil) ;; NOTE: user needs to set this value
+  (org-roam-directory . "") ;; NOTE: user needs to set this value
   :setq
   (org-roam-node-display-template .  `,(concat "${title:*} " (propertize "${tags:10}" 'face 'org-tag)))
   :bind

--- a/lisp/gears/editing/org.el
+++ b/lisp/gears/editing/org.el
@@ -6,3 +6,46 @@
   :config
   (when (gearp! :editing org display-line-numbers)
     (add-hook 'org-mode-hook #'display-line-numbers-mode)))
+
+(leaf org-modern
+  :doc "a modern style for your Org buffers using font locking and text properties"
+  :unless (gearp! :editing -modern)
+  :ensure (org-modern :ref "713beb72aed4db43f8a10feed72136e931eb674a" :host github :repo "minad/org-modern")
+  :custom
+  (org-auto-align-tags			.	nil)
+  (org-tags-column			.	0)
+  (org-catch-invisible-edits		.	'show-and-error)
+  (org-special-ctrl-a/e			.	t)
+  (org-insert-heading-respect-content	.	t)
+  (org-hide-emphasis-markers		.	t)
+  (org-pretty-entities			.	t)
+  (org-agenda-tags-column		.	0)
+  (org-ellipsis				.	"…")
+  :global-minor-mode global-org-modern-mode)
+
+(leaf org-roam
+  :doc "a plain-text knowledge management system. It brings some of Roam's more powerful features into the Org-mode ecosystem"
+  :url "https://github.com/org-roam/org-roam"
+  :when (gearp! :editing org roam)
+  :after org
+  :ensure (org-roam :ref "7cd906b6f8b18a21766228f074aff24586770934" :host github :repo "org-roam/org-roam")
+  :custom
+  (org-roam-directory . nil) ;; NOTE: user needs to set this value
+  :setq
+  (org-roam-node-display-template .  `,(concat "${title:*} " (propertize "${tags:10}" 'face 'org-tag)))
+  :bind
+  ("C-c n l" . org-roam-buffer-toggle)
+  ("C-c n f" . org-roam-node-find)
+  ("C-c n g" . org-roam-graph)
+  ("C-c n i" . org-roam-node-insert)
+  ("C-c n c" . org-roam-capture)
+  ;; for daily notes
+  ("C-c n j" . org-roam-dailies-capture-today)
+  :global-minor-mode org-roam-db-autosync-mode)
+
+(leaf org-noter
+  :doc "a synchronized, Org-mode, document annotator"
+  :url "https://github.com/weirdNox/org-noter"
+  :when (gearp! :editing org noter)
+  :after org
+  :ensure (org-noter :ref "9ead81d42dd4dd5074782d239b2efddf9b8b7b3d" :host github :repo "weirdNox/org-noter"))


### PR DESCRIPTION
Add new packages and tweak things.

Things used for guidance:
- https://sophiebos.io/posts/beautifying-emacs-org-mode/
- https://github.com/SophieBosio/.emacs.d

It looks like this:

<img width="1892" height="1002" alt="image" src="https://github.com/user-attachments/assets/266d0c08-1f28-4819-ad55-804c59b62371" />
